### PR TITLE
.filter() API. A couple of bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,64 @@ Consider the following path and unbound routes:
             this.get();    // match 'GET  /domain/users'
         });
     })
+    
+### Filters #
+
+Often it's convenient to disallow certain requests based on predefined criteria. A great example of this is Authorization:
+
+    function authorize (request, body, cb) {
+      return request.headers.authorized === true 
+          ? cb(null) 
+          : cb(new journey.NotAuthorized('Not Authorized'));
+    }
+    
+    function authorizeAdmin (request, body, cb) {
+      return request.headers.admin === true 
+          ? cb(null) 
+          : cb(new journey.NotAuthorized('Not Admin'));
+    }
+
+Journey exposes this in three separate location through the `filter` API:
+
+#### Set a global filter
+    
+    var router = new(journey.Router)(function (map) {
+        // Define routes here
+    }, { filter: authorize });
+    
+Remark: This filter will not actually be enforced until you use the APIs exposed in (2) and (3)    
+  
+#### Set a scoped filter in your route function
+    
+    var router = new(journey.Router)(function (map) {
+        map.filter(function () {
+            //
+            // Routes in this scope will use the 'authorize' function
+            //
+        });
+        
+        map.filter(authorizeAdmin, function () {
+            //
+            // Routes in this scope will use the 'authorizeAdmin' function
+            //
+        })
+    }, { filter: authorize });
+
+#### Set a filter on an individual route
+    
+    var router = new(journey.Router)(function (map) {
+        map.get('/authorized').filter().bind(function (res, params) {
+            //
+            // This route will be filtered using the 'authorize' function
+            //          
+        });
+        
+        map.get('/admin').filter(authorizeAdmin).bind(function (res, params) {
+            //
+            // This route will be filtered using the 'authorizeAdmin' function
+            //                    
+        });
+    }, { filter: authorize });
 
 ### Accessing the request object #
 

--- a/lib/journey.js
+++ b/lib/journey.js
@@ -51,6 +51,11 @@ var NotImplemented = function (msg) {
     this.headers = {};
     this.body = { error: msg };
 };
+var NotAuthorized = function (msg) {
+    this.status = 403;
+    this.headers = {};
+    this.body = { error: msg || 'Not Authorized' };
+};
 
 journey.env = 'development';
 journey.version = [0, 2, 9];
@@ -85,11 +90,11 @@ journey.map = function (context) {
         paths: [],
         required: {},
 
-        auth: function (handler) { this.auth = handler },
+        auth: function (handler) { this.required['auth'] = handler },
         secure: function (/* variable arguments */) {
             var args = Array.prototype.slice.call(arguments),
                 map = (typeof(args[args.length - 1]) === 'function') && args.pop(),
-                auth = this.auth && args.pop(),
+                auth = args.pop() || this.required['auth'],
                 prev = this.required['auth'];
             
             this.required['auth'] = auth;
@@ -160,7 +165,7 @@ journey.map = function (context) {
                     return this;
                 },
                 secure: function (authHandler) {
-                    return this.ensure('auth', authHandler || that.auth);
+                    return this.ensure('auth', authHandler || that.required['auth']);
                 }
             };
         },
@@ -279,7 +284,7 @@ journey.Router.prototype = {
                     // If the constraint is a function then expect it to have a method signature:
                     //   asyncConstraint(request, body, callback);
                     route.constraints[key](request, body, function (err, result) {
-                      if (err) return cb(err);
+                      if (err || !result) return cb(key === 'auth' ? new NotAuthorized(err.message) : err);
                       checkConstraints();
                     });
                 } else {

--- a/lib/journey.js
+++ b/lib/journey.js
@@ -234,65 +234,98 @@ journey.Router.prototype = {
         }
     },
 
-    resolve: function (request, body) {
+    resolve: function (request, body, dispatcher) {
         var that = this, allowedMethods = [];
-        //
-        // Return the first matching route
-        //
-        var found = find(this.routes, function (route) {
+        
+        function validateRoute(route, cb) {
             // Match the pattern with the url
             var match = (function (pattern) {
                 var path = request.url.pathname;
 
-                if (! path) { throw new(BadRequest) }
+                if (! path) { return new(BadRequest) }
 
                 return (path.length > 1 ? path.slice(1) : path).match(pattern);
             })(route.pattern);
 
             //
-            // Run through the specified constraints,
-            // making sure everything passes.
+            // Return here if no match to avoid potentially expensive
+            // async constraint operations.
             //
-            var constraints = Object.keys(route.constraints).length === 0 ? true :
-                Object.keys(route.constraints).every(function (key) {
-                // Check if the constraint has been defined, then run it.
-                if (key in that.constraints) {
-                    return that.constraints[key](route.constraints[key], request, body);
-                } else {
-                    throw new(Error)("constraint '" + key + "' not found.");
-                }
-            });
-
-            if (match && constraints) {
-                if (! ('handler' in route)) { throw new(NotImplemented)("unbound route") }
-                if ((Array.isArray(route.method) && route.method.indexOf(request.method) !== -1) ||
-                    (route.method === request.method) || !route.method) {
-                    return function (res, params) {
-                        var args = [];
-                        args.push(res);
-                        args.push.apply(args, match.slice(1).map(function (m) {
-                            return /^\d+$/.test(m) ? parseInt(m) : m;
-                        }));
-                        args.push(params);
-                        return route.handler.apply(this, args);
-                    };
-                } else {
-                    if (allowedMethods.indexOf(route.method) === -1) {
-                        allowedMethods.push(route.method);
-                    }
-                    return false;
-                }
+            if (match !== true) { 
+              return match === false ? cb(null, match) : cb(match);
             }
-            return false;
-        });
+            
+            //
+            // Run through the specified constraints,
+            // asynchronously making sure everything passes.
+            //
+            var constraints = Object.keys(route.constraints);
+            
+            //
+            // (cloudhead): This is the crux of the refactor. You were only allowing for synchronous
+            //              constraint functions, which isn't going to work when you think about auth
+            //              and sessions. You can't guarentee that every user will be in-memory.
+            //
+            function checkConstraints() {
+              if (constraints.length === 0) {
+                return checkRoute();
+              }
+              
+              var key = constraints.shift();
+              if (key in that.constraints) {
+                  // Keep support for existing (< 0.2.9) synchronous constraints 
+                  that.constraints[key](route.constraints[key], request, body)) ? checkConstraints() : cb(null, false);
+              } else if (typeof route.constraints[key] === 'function') {
+                  // If the constraint is a function then expect it to have a method signature:
+                  //   asyncConstraint(request, body, callback);
+                  route.constraints[key](request, body, function (err, result) {
+                    if (err) return cb(err);
+                    checkConstraints();
+                  });
+              } else {
+                  cb(new(Error)("constraint '" + key + "' not found."));
+              }
+            }
+            
+            checkConstraints();
 
-        if (found) {
-            return found;
-        } else if (allowedMethods.length) {
-            throw new(MethodNotAllowed)(allowedMethods.join(','));
-        } else {
-            return false;
+            function checkRoute() {
+              // If there is no handler for this route, return a new NotImplemented exception
+              if (! ('handler' in route)) { return cb(new(NotImplemented)("unbound route")) }
+
+              // Otherwise, validate the route method, and return accordingly
+              if ((Array.isArray(route.method) && route.method.indexOf(request.method) !== -1) ||
+                  (route.method === request.method) || !route.method) {
+                  return cb(null, function (res, params) {
+                      var args = [];
+                      args.push(res);
+                      args.push.apply(args, match.slice(1).map(function (m) {
+                          return /^\d+$/.test(m) ? parseInt(m) : m;
+                      }));
+                      args.push(params);
+                      return route.handler.apply(this, args);
+                  });
+              } else {
+                  if (allowedMethods.indexOf(route.method) === -1) {
+                      allowedMethods.push(route.method);
+                  }
+                  return cb(null, false);
+              }
+            }
         }
+        
+        //
+        // Return the first matching route
+        //
+        asyncFind(this.routes, validateRoute, function (err, found) {
+          if (found) {
+              dispatcher(null, found);
+          } else if (allowedMethods.length) {
+              dispatcher(new(MethodNotAllowed)(allowedMethods.join(',')));
+          } else {
+              dispatcher(null, false);
+          }
+        });
     },
 
     // This function glues together the request resolver, with the responder.
@@ -317,43 +350,44 @@ journey.Router.prototype = {
             }
         }
 
-        try {
-            resolved = this.resolve(request, body);
-        } catch (e) {
-            if (e.status) { // If it's an HTTP Error
+  
+        this.resolve(request, body, function (err, resolved) {
+          if (err) {
+            if (err.status) { // If it's an HTTP Error
                 return respond({
-                    headers: e.headers || {},
-                    status: e.status,
-                    body: JSON.stringify(e.body)
+                    headers: err.headers || {},
+                    status: err.status,
+                    body: JSON.stringify(err.body)
                 });
             } else {
-                throw e;
+                throw err;
             }
-        }
+          }
+          
+          route = this.draw(request, respond);
 
-        route = this.draw(request, respond);
+          if (resolved) {
+              if (body) {
+                  parser = /^application\/json/.test(
+                      request.headers["content-type"]
+                  ) ? JSON.parse : querystring.parse;
 
-        if (resolved) {
-            if (body) {
-                parser = /^application\/json/.test(
-                    request.headers["content-type"]
-                ) ? JSON.parse : querystring.parse;
+                  try {
+                      body = parser(body);
+                  } catch (e) {
+                      return respond(new(BadRequest)("malformed data"));
+                  }
 
-                try {
-                    body = parser(body);
-                } catch (e) {
-                    return respond(new(BadRequest)("malformed data"));
-                }
-
-                // If the body is an Array, we want to return params as an array,
-                // else, an object. The `mixin` function will preserve the type
-                // of its first parameter.
-                params = Array.isArray(body) ? mixin(body, params) : mixin(params, body);
-            }
-            return route.go(resolved, params);
-        } else {
-            return respond(new(NotFound)("request not found"));
-        }
+                  // If the body is an Array, we want to return params as an array,
+                  // else, an object. The `mixin` function will preserve the type
+                  // of its first parameter.
+                  params = Array.isArray(body) ? mixin(body, params) : mixin(params, body);
+              }
+              return route.go(resolved, params);
+          } else {
+              return respond(new(NotFound)("request not found"));
+          }
+        });
     },
 
     // A constructor of sorts, which returns a 'Routing context', in which the response
@@ -463,9 +497,26 @@ function mixin(target) {
     });
     return target;
 }
-function find(array, fun) {
-    for (var i = 0; i < array.length; i++) {
-        if (ret = fun(array[i])) return ret;
-    }
-    return false;
+
+// Asynchronously iterate over the array, executing iterator
+// passing the result to callback if it is not false
+function asyncFind(array, iterator, cb) {
+    var completed = 0;
+    
+    function iterate() {
+      iterator(array[completed], function (err, found) {
+        if (err) return cb(err);
+        else if (found !== false) {
+          return cb(null, found);
+        }
+        
+        completed += 1;
+        if (completed === array.length) {
+            return(null, false);
+        }
+        iterate();
+      });
+    } 
+    
+    iterate();
 }

--- a/lib/journey.js
+++ b/lib/journey.js
@@ -83,25 +83,43 @@ journey.Router.methods = ['GET', 'PUT', 'POST', 'DELETE', 'HEAD'];
 journey.map = function (context) {
     return {
         paths: [],
+        required: {},
 
+        auth: function (handler) { this.auth = handler },
+        secure: function (/* variable arguments */) {
+            var args = Array.prototype.slice.call(arguments),
+                map = (typeof(args[args.length - 1]) === 'function') && args.pop(),
+                auth = this.auth && args.pop(),
+                prev = this.required['auth'];
+            
+            this.required['auth'] = auth;
+            map.call(this, this);
+            
+            this.required['auth'] = prev;
+        },
+        
         get:  function (pattern, opts) { return this.route('GET',    pattern, opts) },
         put:  function (pattern, opts) { return this.route('PUT',    pattern, opts) },
         post: function (pattern, opts) { return this.route('POST',   pattern, opts) },
         del:  function (pattern, opts) { return this.route('DELETE', pattern, opts) },
 
         route: function (/* variable arguments */) {
-            var route, args = Array.prototype.slice.call(arguments).filter(function (a) { return a }),
+            var that = this, route, 
+                args = Array.prototype.slice.call(arguments).filter(function (a) { return a }),
                 // Defaults
                 pattern     = this.paths.length ? '' : /.*/,
                 ignoreCase  = false,
                 method      = journey.Router.methods,
                 constraints = {};
 
+            // Mixin the shared required constraints
+            mixin(constraints, this.required);
+            
             args.forEach(function (arg) {
                 if (journey.Router.methods.indexOf(arg) !== -1 || Array.isArray(arg)) {
                     method = arg;
                 } else if (typeof(arg) === "object") {
-                    constraints = arg;
+                    mixin(constraints, arg);
                 } else if (typeof(arg) === "string" || arg.exec) {
                     pattern = arg;
                 } else {
@@ -136,6 +154,13 @@ journey.map = function (context) {
                 bind: function (handler) {
                     route.handler = handler;
                     return route;
+                },
+                ensure: function (name, handler) {
+                    route.constraints[name] = handler;
+                    return this;
+                },
+                secure: function (authHandler) {
+                    return this.ensure('auth', authHandler || that.auth);
                 }
             };
         },

--- a/lib/journey.js
+++ b/lib/journey.js
@@ -59,6 +59,11 @@ var NotAuthorized = journey.NotAuthorized = function (msg) {
 
 journey.env = 'development';
 journey.version = [0, 2, 9];
+journey.options = {
+  strict: false,
+  strictUrls: true
+};
+
 
 //
 // The Router
@@ -76,7 +81,7 @@ journey.Router = function Router(routes, options) {
     });
 
     this.routes = [];
-    this.options = options || {};
+    this.options = mixin({}, journey.options, options);
 
     // Call map() in the context of `this.map`, so `this`
     // can be used instead of the passed argument.
@@ -142,9 +147,10 @@ journey.map = function (context) {
             // Trim trailing and duplicate slashes and add ^$ markers
             pattern = '^' + this.paths.concat(pattern ? [pattern] : [])
                                       .join('/')
-                                      .match(/^\^?(.*?)\$?$/)[1]                // Strip ^ and $
-                                      .replace(/^(\/|\\\/)(?!$)/, '')           // Strip root / if pattern != '/'
-                                      .replace(/(\/|\\\/)+/g, '/') + '[\\/]?$'; // Squeeze slashes
+                                      .match(/^\^?(.*?)\$?$/)[1]       // Strip ^ and $
+                                      .replace(/^(\/|\\\/)(?!$)/, '')  // Strip root / if pattern != '/'
+                                      .replace(/(\/|\\\/)+/g, '/');    // Squeeze slashes
+            pattern += context.options.strictUrls ? '$' : '\\/?$';     // Add optional trailing slash if requested
             
             pattern = new(RegExp)(pattern, ignoreCase ? 'i' : '');
             

--- a/lib/journey.js
+++ b/lib/journey.js
@@ -251,8 +251,8 @@ journey.Router.prototype = {
             // Return here if no match to avoid potentially expensive
             // async constraint operations.
             //
-            if (match !== true) { 
-              return match === false ? cb(null, match) : cb(match);
+            if (!Array.isArray(match)) { 
+              return match === null ? cb(null, false) : cb(match);
             }
             
             //
@@ -267,50 +267,50 @@ journey.Router.prototype = {
             //              and sessions. You can't guarentee that every user will be in-memory.
             //
             function checkConstraints() {
-              if (constraints.length === 0) {
-                return checkRoute();
-              }
+                if (constraints.length === 0) {
+                  return checkRoute();
+                }
               
-              var key = constraints.shift();
-              if (key in that.constraints) {
-                  // Keep support for existing (< 0.2.9) synchronous constraints 
-                  that.constraints[key](route.constraints[key], request, body)) ? checkConstraints() : cb(null, false);
-              } else if (typeof route.constraints[key] === 'function') {
-                  // If the constraint is a function then expect it to have a method signature:
-                  //   asyncConstraint(request, body, callback);
-                  route.constraints[key](request, body, function (err, result) {
-                    if (err) return cb(err);
-                    checkConstraints();
-                  });
-              } else {
-                  cb(new(Error)("constraint '" + key + "' not found."));
-              }
+                var key = constraints.shift();
+                if (key in that.constraints) {
+                    // Keep support for existing (< 0.2.9) synchronous constraints 
+                    that.constraints[key](route.constraints[key], request, body) ? checkConstraints() : cb(null, false);
+                } else if (typeof route.constraints[key] === 'function') {
+                    // If the constraint is a function then expect it to have a method signature:
+                    //   asyncConstraint(request, body, callback);
+                    route.constraints[key](request, body, function (err, result) {
+                      if (err) return cb(err);
+                      checkConstraints();
+                    });
+                } else {
+                    cb(new(Error)("constraint '" + key + "' not found."));
+                }
             }
             
             checkConstraints();
 
             function checkRoute() {
-              // If there is no handler for this route, return a new NotImplemented exception
-              if (! ('handler' in route)) { return cb(new(NotImplemented)("unbound route")) }
+                // If there is no handler for this route, return a new NotImplemented exception
+                if (! ('handler' in route)) { return cb(new(NotImplemented)("unbound route")) }
 
-              // Otherwise, validate the route method, and return accordingly
-              if ((Array.isArray(route.method) && route.method.indexOf(request.method) !== -1) ||
-                  (route.method === request.method) || !route.method) {
-                  return cb(null, function (res, params) {
-                      var args = [];
-                      args.push(res);
-                      args.push.apply(args, match.slice(1).map(function (m) {
-                          return /^\d+$/.test(m) ? parseInt(m) : m;
-                      }));
-                      args.push(params);
-                      return route.handler.apply(this, args);
-                  });
-              } else {
-                  if (allowedMethods.indexOf(route.method) === -1) {
-                      allowedMethods.push(route.method);
-                  }
-                  return cb(null, false);
-              }
+                // Otherwise, validate the route method, and return accordingly
+                if ((Array.isArray(route.method) && route.method.indexOf(request.method) !== -1) ||
+                    (route.method === request.method) || !route.method) {
+                    return cb(null, function (res, params) {
+                        var args = [];
+                        args.push(res);
+                        args.push.apply(args, match.slice(1).map(function (m) {
+                            return /^\d+$/.test(m) ? parseInt(m) : m;
+                        }));
+                        args.push(params);
+                        return route.handler.apply(this, args);
+                    });
+                } else {
+                    if (allowedMethods.indexOf(route.method) === -1) {
+                        allowedMethods.push(route.method);
+                    }
+                    return cb(null, false);
+                }
             }
         }
         
@@ -318,7 +318,10 @@ journey.Router.prototype = {
         // Return the first matching route
         //
         asyncFind(this.routes, validateRoute, function (err, found) {
-          if (found) {
+          if (err) {
+              dispatcher(err);
+          }
+          else if (found) {
               dispatcher(null, found);
           } else if (allowedMethods.length) {
               dispatcher(new(MethodNotAllowed)(allowedMethods.join(',')));
@@ -331,10 +334,10 @@ journey.Router.prototype = {
     // This function glues together the request resolver, with the responder.
     // It creates a new `route` context, in which the response will be generated.
     dispatch: function (request, body, respond) {
-        var resolved, route, parser,
-            params = querystring.parse(request.url.query || ''),
+        var route, parser, that = this,
+            params = querystring.parse(request.url.query || null),
             accepts = request.headers.accept;
-
+        
         accepts = accepts && accepts.split(/[,;] */);
 
         // Journey being a JSON-only server, we expect the 'Accept' header
@@ -350,7 +353,6 @@ journey.Router.prototype = {
             }
         }
 
-  
         this.resolve(request, body, function (err, resolved) {
           if (err) {
             if (err.status) { // If it's an HTTP Error
@@ -364,7 +366,7 @@ journey.Router.prototype = {
             }
           }
           
-          route = this.draw(request, respond);
+          route = that.draw(request, respond);
 
           if (resolved) {
               if (body) {
@@ -502,7 +504,7 @@ function mixin(target) {
 // passing the result to callback if it is not false
 function asyncFind(array, iterator, cb) {
     var completed = 0;
-    
+
     function iterate() {
       iterator(array[completed], function (err, found) {
         if (err) return cb(err);
@@ -512,7 +514,7 @@ function asyncFind(array, iterator, cb) {
         
         completed += 1;
         if (completed === array.length) {
-            return(null, false);
+            return cb(null, false);
         }
         iterate();
       });

--- a/lib/journey.js
+++ b/lib/journey.js
@@ -23,22 +23,22 @@ var escapeRe = (function () {
 
 var journey = exports;
 
-var BadRequest = function (msg) {
+var BadRequest = journey.BadRequest = function (msg) {
     this.status = 400;
     this.headers = {};
     this.body = { error: msg };
 };
-var NotFound = function (msg) {
+var NotFound = journey.NotFound = function (msg) {
     this.status = 404;
     this.headers = {};
     this.body = { error: msg };
 };
-var MethodNotAllowed = function (allowed) {
+var MethodNotAllowed = journey.MethodNotAllowed = function (allowed) {
     this.status = 405;
     this.headers = { allow: allowed };
     this.body = { error: "method not allowed." };
 };
-var NotAcceptable = function (accept) {
+var NotAcceptable = journey.NotAcceptable = function (accept) {
     this.status = 406;
     this.headers = {};
     this.body = {
@@ -46,12 +46,12 @@ var NotAcceptable = function (accept) {
         only: "application/json"
     };
 };
-var NotImplemented = function (msg) {
+var NotImplemented = journey.NotImplemented = function (msg) {
     this.status = 501;
     this.headers = {};
     this.body = { error: msg };
 };
-var NotAuthorized = function (msg) {
+var NotAuthorized = journey.NotAuthorized = function (msg) {
     this.status = 403;
     this.headers = {};
     this.body = { error: msg || 'Not Authorized' };
@@ -90,17 +90,16 @@ journey.map = function (context) {
         paths: [],
         required: {},
 
-        auth: function (handler) { this.required['auth'] = handler },
-        secure: function (/* variable arguments */) {
+        filter: function (/* variable arguments */) {
             var args = Array.prototype.slice.call(arguments),
                 map = (typeof(args[args.length - 1]) === 'function') && args.pop(),
-                auth = args.pop() || this.required['auth'],
-                prev = this.required['auth'];
+                filter = args.pop() || context.options.filter,
+                prev = this.required['filter'];
             
-            this.required['auth'] = auth;
+            this.required['filter'] = filter;
             map.call(this, this);
             
-            this.required['auth'] = prev;
+            this.required['filter'] = prev;
         },
         
         get:  function (pattern, opts) { return this.route('GET',    pattern, opts) },
@@ -164,8 +163,8 @@ journey.map = function (context) {
                     route.constraints[name] = handler;
                     return this;
                 },
-                secure: function (authHandler) {
-                    return this.ensure('auth', authHandler || that.required['auth']);
+                filter: function (handler) {
+                    return this.ensure('filter', handler || context.options.filter);
                 }
             };
         },
@@ -238,7 +237,7 @@ journey.Router.prototype = {
             return Boolean(assert(request, body));
         }
     },
-
+    
     resolve: function (request, body, dispatcher) {
         var that = this, allowedMethods = [];
         
@@ -283,8 +282,8 @@ journey.Router.prototype = {
                 } else if (typeof route.constraints[key] === 'function') {
                     // If the constraint is a function then expect it to have a method signature:
                     //   asyncConstraint(request, body, callback);
-                    route.constraints[key](request, body, function (err, result) {
-                      if (err || !result) return cb(key === 'auth' ? new NotAuthorized(err.message) : err);
+                    route.constraints[key](request, body, function (err) {
+                      if (err) return cb(err);
                       checkConstraints();
                     });
                 } else {

--- a/lib/journey.js
+++ b/lib/journey.js
@@ -143,12 +143,12 @@ journey.map = function (context) {
             // Trim trailing and duplicate slashes and add ^$ markers
             pattern = '^' + this.paths.concat(pattern ? [pattern] : [])
                                       .join('/')
-                                      .match(/^\^?(.*?)\$?$/)[1]          // Strip ^ and $
-                                      .replace(/^(\/|\\\/)(?!$)/, '')     // Strip root / if pattern != '/'
-                                      .replace(/(\/|\\\/)+/g, '/') + '$'; // Squeeze slashes
-
+                                      .match(/^\^?(.*?)\$?$/)[1]                // Strip ^ and $
+                                      .replace(/^(\/|\\\/)(?!$)/, '')           // Strip root / if pattern != '/'
+                                      .replace(/(\/|\\\/)+/g, '/') + '[\\/]?$'; // Squeeze slashes
+            
             pattern = new(RegExp)(pattern, ignoreCase ? 'i' : '');
-
+            
             context.routes.push(route = {
                 pattern: pattern,
                 method: method,

--- a/test/journey-test.js
+++ b/test/journey-test.js
@@ -138,15 +138,14 @@ vows.describe('Journey').addVows({
             var promise = new(events.EventEmitter);
             router.routes.unshift({
                 pattern: /^noparams$/,
-                method: 'GET', handler: function (res) {
-                    promise.emit('success', arguments);
+                method: 'GET', handler: function (res, params) {
+                    promise.emit('success', params);
                 }, success: undefined, constraints: {}
             });
             router.route(mock.mockRequest('GET', '/noparams', {}));
             return promise;
         },
-        "should pass an empty params object": function (args) {
-            var params = args[args.length - 1];
+        "should pass an empty params object": function (params) {
             assert.isObject(params);
             assert.equal(Object.keys(params).length, 0);
         }
@@ -251,7 +250,7 @@ vows.describe('Journey').addVows({
     },
     // Trying to access an undefined function will result in a 500,
     // as long as the uri format is valid
-    "A route binded to an undefined function": {
+    "A route bound to an undefined function": {
         topic: function () {
             return get('/undefined');
         },
@@ -296,7 +295,7 @@ vows.describe('Journey').addVows({
         "returns a 500": function (res) {
             assert.equal(res.status, 500);
         }
-    },
+    }
 }).addVows({
     "Scoped routes": {
         "A request to a scope with no routes": {

--- a/test/journey-test.js
+++ b/test/journey-test.js
@@ -74,6 +74,13 @@ var router = new(journey.Router)(function (map) {
 
     map.put('home/assert', { assert: function (res, body) { return body.length === 9; } }).
         bind(function (res) { res.send(200, {"Content-Type":"text/html"}, "OK"); });
+        
+    //
+    // Setup a secure portion of the router
+    //
+    map.auth(function (request, body) {
+      request.headers.authorized = true
+    });
 });
 
 var mock = require('lib/journey/mock-request').mock(router);


### PR DESCRIPTION
Expose a filter API so that arbitrary functions can preprocess incoming routes based on the request, and body. Also allow for optional matching of trailing slashed based on 'strictUrls' option in Router. Fix one failing test.

https://gist.github.com/669679
