### PR TITLE
0.6 compatibility

### DIFF
--- a/example/http-server.js
+++ b/example/http-server.js
@@ -1,16 +1,17 @@
-var path = require('path'),
-    sys = require('sys');
+var util = require('util');
 
-require.paths.unshift(path.join(__dirname, '..', 'lib'));
-
-var journey = require('journey');
+var journey = require('../lib/journey');
 
 //
 // Create a Router object with an associated routing table
 //
-var router = new(journey.Router)(function (map) {
-    map.root.bind(function (res) { res.send("Welcome") }); // GET '/'
-    map.get('/version').bind(function (res) {
+var router = new(journey.Router);
+
+router.map(function () {
+    this.root.bind(function (req, res) { // GET '/'
+        res.send(200, {}, "Welcome");
+    });
+    this.get('/version').bind(function (req, res) {
         res.send(200, {}, { version: journey.version.join('.') });
     });
 });
@@ -23,11 +24,11 @@ require('http').createServer(function (request, response) {
         //
         // Dispatch the request to the router
         //
-        router.route(request, body, function (result) {
+        router.handle(request, body, function (result) {
             response.writeHead(result.status, result.headers);
             response.end(result.body);
         });
     });
 }).listen(8080);
 
-sys.puts('journey listening at http://127.0.0.1:8080');
+util.puts('journey listening at http://127.0.0.1:8080');

--- a/lib/journey.js
+++ b/lib/journey.js
@@ -2,7 +2,6 @@ var path = require('path');
 
 var http = require("http"),
   events = require('events'),
-      fs = require("fs"),
      url = require('url');
 
 var querystring = require('querystring');

--- a/lib/journey.js
+++ b/lib/journey.js
@@ -1,16 +1,13 @@
 var path = require('path');
 
-require.paths.unshift(__dirname);
-
-var sys = require("sys"),
-   http = require("http"),
- events = require('events'),
-     fs = require("fs"),
-    url = require('url');
+var http = require("http"),
+  events = require('events'),
+      fs = require("fs"),
+     url = require('url');
 
 var querystring = require('querystring');
 
-var errors = require('journey/errors');
+var errors = require('./journey/errors');
 
 // Escape RegExp characters in a string
 var escapeRe = (function () {

--- a/test/journey-test.js
+++ b/test/journey-test.js
@@ -1,15 +1,12 @@
-var sys = require('sys'),
-   http = require('http'),
- assert = require('assert'),
-   path = require('path'),
- events = require('events'),
-    url = require('url');
+var http = require('http'),
+  assert = require('assert'),
+    path = require('path'),
+  events = require('events'),
+     url = require('url');
 
 var vows = require('vows');
 
-require.paths.unshift(__dirname, path.join(__dirname, '..'));
-
-var journey = require('lib/journey');
+var journey = require('../lib/journey');
 
 var resources = {
     "home": {
@@ -111,7 +108,7 @@ router.map(function (map) {
     });
 });
 
-var mock = require('lib/journey/mock-request').mock(router);
+var mock = require('../lib/journey/mock-request').mock(router);
 
 var get = mock.get,
     del = mock.del,

--- a/test/journey-test.js
+++ b/test/journey-test.js
@@ -1,8 +1,6 @@
 var http = require('http'),
   assert = require('assert'),
-    path = require('path'),
-  events = require('events'),
-     url = require('url');
+  events = require('events');
 
 var vows = require('vows');
 


### PR DESCRIPTION
Main changes:
- removed references to mutable `require.paths`,
- replaced/removed references to `sys`,
- made the example work,
- a bit of refactoring (unused `require`s).

Test and example still work on `node v0.4.12`.
