### PR TITLE
Handle Buffers being passed back (even though journey is intended to be JSON only)

### DIFF
--- a/lib/journey.js
+++ b/lib/journey.js
@@ -176,11 +176,15 @@ journey.Router.prototype = {
                 outcome.headers["Server"] = "journey/" + journey.version.join('.');
 
                 if (outcome.body) {
-                    if (typeof(outcome.body) !== 'string') {
-                        outcome.headers["Content-Type"] = "application/json;charset=utf-8";
-                        outcome.body = JSON.stringify(outcome.body);
+                    if (Buffer.isBuffer(outcome.body)) {
+                        outcome.headers['Content-Length'] = outcome.body.length;
+                    }else{
+                        if (typeof(outcome.body) !== 'string') {
+                            outcome.headers["Content-Type"] = "application/json;charset=utf-8";
+                            outcome.body = JSON.stringify(outcome.body);
+                        }
+                        outcome.headers['Content-Length'] = Buffer.byteLength(outcome.body);
                     }
-                    outcome.headers['Content-Length'] = Buffer.byteLength(outcome.body);
                 } else {
                     delete(outcome.headers["Content-Type"]);
                 }


### PR DESCRIPTION
If a buffer is returned from a route, currently Journey will error on the line, as byteLength is expecting a string.

``` Buffer.byteLength(outcome.body);```

Seeing as converting a Buffer to JSON is not a huge amount of use, my patch returns the buffer, and retains the Content-Type as is.

I know journey is supposed to be JSON-only, but the code change to support binary files is minimal and low impact.
```
