### PR TITLE
Allow the return of strings instead of always JSON

### DIFF
--- a/lib/journey.js
+++ b/lib/journey.js
@@ -376,7 +376,9 @@ journey.Router.prototype = {
                         case "object":
                             return mixin({}, baseResponse, { body: response });
                         case "string":
-                            return mixin({}, baseResponse, { body: { journey: response } });
+                            var base = {headers: {"Content-Type": "text/html"},
+                                        status:  baseResponse.status};
+                            return mixin({}, base, { body: response });
                         case "number":
                             return mixin({}, baseResponse, { status: response });
                         case "array":


### PR DESCRIPTION
When I was using the journey router, there were times when I wanted to return pure string responses instead of json. An example would be returning some html.

This commit changes the behavior of the request.send when passed strings. Instead of making json with "journey" as the key, this keeps it as a string.
