### PR TITLE
401 Error must return header "WWW-Authenticate"

### DIFF
--- a/lib/journey/errors.js
+++ b/lib/journey/errors.js
@@ -29,9 +29,9 @@ this.NotImplemented = function (msg) {
     this.headers = {};
     this.body = { error: msg };
 };
-this.NotAuthorized = function (msg) {
+this.NotAuthorized = function (msg, realm) {
     this.status = 401;
-    this.headers = {};
+    this.headers = {'Content-Type': 'text/plain', 'WWW-Authenticate': 'Basic realm="'+ (realm || 'Journey REST API') +'"'};
     this.body = { error: msg || 'Not Authorized' };
 };
 this.Forbidden = function (msg) {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,14 @@
   "url"           : "http://cloudhead.io/journey",
   "keywords"      : ["http", "router", "json"],
   "author"        : "Alexis Sellier <self@cloudhead.net>",
-  "contributors"  : [],
+  "contributors"  : [
+    {"name": "Philippe Guilbault", "email": "pĥilippe_guilbault@gmail.com", "url":"http://newbiverse.com"},
+    {"name": "Coen Hyde", "email": "coen.hyde@gmail.com", "url":"http://coenhyde.com"},
+    {"name": "Ben Chatelain", "email": "ben@sopods.com", "url":"http://sopods.com"},
+    {"name": "Maciej Małecki", "email": "me@mmalecki.com", "url":"http://mmalecki.com"},
+    {"name": "Iván Loire", "email": "ivan@iloire.com", "url":"http://www.iloire.com"},
+    {"name": "Charlie Robbins", "email": "charlie@nodejitsu.com", "url":"http://blog.nodejitsu.com"}
+  ],
   "licenses"      : ["Apache 2.0"],
   "dependencies"  : [],
   "devDependencies": {
@@ -15,7 +22,7 @@
     "test"        : "./node_modules/vows/bin/vows"
   },
   "main"          : "./lib/journey",
-  "version"       : "0.4.0-pre-3",
+  "version"       : "0.4.1",
   "directories"   : { "test": "./test" },
   "engines"       : { "node": "> 0.2.6" }
 }


### PR DESCRIPTION
The error 401 error must return the header "WWW-Authenticate" for certain browser to send back the "authentication" header.

I also incremented the version and added contributors from previously closed pull requests.
