### PR TITLE
Numeric strings beginning with "0" treated as strings instead of convert them to Integers

### DIFF
--- a/lib/journey.js
+++ b/lib/journey.js
@@ -248,7 +248,7 @@ journey.Router.prototype = {
 
                         args.push(res);
                         args.push.apply(args, match.slice(1).map(function (m) {
-                            return /^\d+$/.test(m) ? parseInt(m) : m;
+                            return /^[^0]\d+$/.test(m) ? parseInt(m,10) : m;
                         }));
                         args.push(params);
                         return route.handler.apply(this, args);

--- a/lib/journey.js
+++ b/lib/journey.js
@@ -248,7 +248,7 @@ journey.Router.prototype = {
 
                         args.push(res);
                         args.push.apply(args, match.slice(1).map(function (m) {
-                            return /^[^0]\d+$/.test(m) ? parseInt(m,10) : m;
+                            return /^[1-9]+\d*$/.test(m) ? parseInt(m,10) : m;
                         }));
                         args.push(params);
                         return route.handler.apply(this, args);


### PR DESCRIPTION
Patch for supporting passing numbers as strings. For example "0001" is treated as string instead of 1. Also added seccond parameter to parseInt for setting base 10 for convertions instead of octal.
